### PR TITLE
Avoid listing all files in repo for invalid path

### DIFF
--- a/codeowners_diff.py
+++ b/codeowners_diff.py
@@ -106,10 +106,8 @@ def _path_to_glob(path: str) -> str:
 
 def find_affected_files(path: str, repo: GitRepo) -> frozenset[str]:
     glob_ = _path_to_glob(path)
-    paths = glob.glob(
-        glob_, root_dir=repo.root_dir, recursive=True,
-    )
-    return repo.ls_files(paths)
+    paths = glob.glob(glob_, root_dir=repo.root_dir, recursive=True)
+    return repo.ls_files(paths) if paths else frozenset()
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/tests/codeowners_diff_test.py
+++ b/tests/codeowners_diff_test.py
@@ -76,6 +76,7 @@ def repo_with_files(tmp_path_factory: pytest.TempPathFactory):
         ('/foo/bar/', {'foo/bar/baz.py'}),
         ('foo/bar/baz.py', {'foo/bar/baz.py'}),
         ('/foo/fizz', {'foo/fizz/buzz/bang.py'}),
+        ('/invalid', frozenset()),
     ),
 )
 def test_find_affected_files(


### PR DESCRIPTION
When an invalid path is found in the `CODEOWNERS` file, the glob will not match any files resulting in an empty set being returned. This will return the wrong result - all files in the repo - as well as taking a very, very long time! This is because, for empty `paths`, the command executed is `git ls-files --`.