### PR TITLE
Ensure no files are returned if no paths are checked

### DIFF
--- a/codeowners_diff.py
+++ b/codeowners_diff.py
@@ -36,6 +36,9 @@ class GitRepo:
         )
 
     def ls_files(self, paths: Sequence[str]) -> frozenset[str]:
+        if not paths:
+            return frozenset()
+
         return frozenset(
             subprocess.check_output(
                 ('git', 'ls-files', '--', *paths),

--- a/tests/codeowners_diff_test.py
+++ b/tests/codeowners_diff_test.py
@@ -79,6 +79,7 @@ def repo_with_files(tmp_path_factory: pytest.TempPathFactory):
         ('/foo/bar/', {'foo/bar/baz.py'}),
         ('foo/bar/baz.py', {'foo/bar/baz.py'}),
         ('/foo/fizz', {'foo/fizz/buzz/bang.py'}),
+        ('/does/not/exist', frozenset()),
     ),
 )
 def test_find_affected_files(


### PR DESCRIPTION
Prior to this change, if we passed an empty sequence to `ls_files`, we
would run `git ls-files --`, which would return *all* of the files in
the repository, which is the complete opposite of the expected
behaviour. This happened when a non-existent path was present in the
`CODEOWNERS` file.

This change adds a test for the circumstance and fixes the bug.