### PR TITLE
Handle commit reference arguments like `git diff`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## Changed
+
+- `--repo-root` option is now `-C`.
+  This matches the `git` CLI.
+
 ## v0.1.1 (2024-03-12)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - `--repo-root` option is now `-C`.
   This matches the `git` CLI.
+- The arguments passed to `codeowners-diff`
+  now behave like the arguments `git diff`:
+
+  command                   | previous comparison | new comparison
+  ------------------------- | ------------------- | ------------------------
+  `codeowners-diff foo bar` | `bar` from `foo`    | `bar` from `foo`
+  `codeowners-diff foo`     | `HEAD` from `foo`   | working tree from `foo`
+  `codeowners-diff`         | `HEAD` from `main`  | working tree from `HEAD`
 
 ## v0.1.1 (2024-03-12)
 

--- a/codeowners_diff.py
+++ b/codeowners_diff.py
@@ -138,8 +138,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         help='default: %(default)s',
     )
     parser.add_argument(
-        '-r', '--repo-root',
-        default=None,
+        '-C',
+        dest='repo_root', default=None,
         help='git repository to run the tool in (default: current directory)',
     )
     args = parser.parse_args(argv)

--- a/tests/end_to_end_test.py
+++ b/tests/end_to_end_test.py
@@ -15,7 +15,7 @@ def test_compare_two_branches(
     _create_branch(tmp_path, 'branch-a', '@some-user')
     _create_branch(tmp_path, 'branch-b', '@another/team')
 
-    codeowners_diff.main(('branch-a', 'branch-b', '--repo-root', str(tmp_path)))
+    codeowners_diff.main(('branch-a', 'branch-b', '-C', str(tmp_path)))
 
     captured = capsys.readouterr()
     assert captured.out == """\
@@ -35,7 +35,7 @@ def test_compare_HEAD_with_another_branch(
     _create_branch(tmp_path, 'branch-a', '@some-user')
     _create_branch(tmp_path, 'branch-b', '@another/team')  # HEAD
 
-    codeowners_diff.main(('branch-a', '--repo-root', str(tmp_path)))
+    codeowners_diff.main(('branch-a', '-C', str(tmp_path)))
 
     captured = capsys.readouterr()
     assert captured.out == """\
@@ -54,7 +54,7 @@ def test_compare_HEAD_with_main(
     _create_git_repo(tmp_path)
     _create_branch(tmp_path, 'branch-a', '@some-user')  # HEAD
 
-    codeowners_diff.main(('--repo-root', str(tmp_path)))
+    codeowners_diff.main(('-C', str(tmp_path)))
 
     captured = capsys.readouterr()
     assert captured.out == """\

--- a/tests/end_to_end_test.py
+++ b/tests/end_to_end_test.py
@@ -28,12 +28,19 @@ def test_compare_two_branches(
     assert captured.err == ''
 
 
-def test_compare_HEAD_with_another_branch(
+def test_compare_working_tree_with_another_branch(
         tmp_path: Path, capsys: pytest.CaptureFixture[str],
 ) -> None:
     _create_git_repo(tmp_path)
     _create_branch(tmp_path, 'branch-a', '@some-user')
-    _create_branch(tmp_path, 'branch-b', '@another/team')  # HEAD
+
+    # Change the working copy of the CODEOWNERS file,
+    # without committing it.
+    subprocess.run(('git', 'switch', 'main'), cwd=tmp_path)
+    (tmp_path / '.github').mkdir(exist_ok=True)
+    (tmp_path / '.github' / 'CODEOWNERS').write_text("""\
+* @another/team
+""")
 
     codeowners_diff.main(('branch-a', '-C', str(tmp_path)))
 
@@ -41,18 +48,24 @@ def test_compare_HEAD_with_another_branch(
     assert captured.out == """\
 1 files have changed ownership:
 
-| file             | `branch-a`   | `HEAD`        |
-|:-----------------|:-------------|:--------------|
-| `source_code.py` | @some-user   | @another/team |
+| file             | `branch-a`   | working tree   |
+|:-----------------|:-------------|:---------------|
+| `source_code.py` | @some-user   | @another/team  |
 """
     assert captured.err == ''
 
 
-def test_compare_HEAD_with_main(
+def test_compare_working_tree_with_HEAD(
         tmp_path: Path, capsys: pytest.CaptureFixture[str],
 ) -> None:
-    _create_git_repo(tmp_path)
-    _create_branch(tmp_path, 'branch-a', '@some-user')  # HEAD
+    _create_git_repo(tmp_path)  # HEAD
+
+    # Change the working copy of the CODEOWNERS file,
+    # without committing it.
+    (tmp_path / '.github').mkdir(exist_ok=True)
+    (tmp_path / '.github' / 'CODEOWNERS').write_text("""\
+* @some-user
+""")
 
     codeowners_diff.main(('-C', str(tmp_path)))
 
@@ -60,9 +73,9 @@ def test_compare_HEAD_with_main(
     assert captured.out == """\
 1 files have changed ownership:
 
-| file             | `main`   | `HEAD`     |
-|:-----------------|:---------|:-----------|
-| `source_code.py` |          | @some-user |
+| file             | `HEAD`   | working tree   |
+|:-----------------|:---------|:---------------|
+| `source_code.py` |          | @some-user     |
 """
     assert captured.err == ''
 


### PR DESCRIPTION
This makes our interface more like `git diff`
(https://git-scm.com/docs/git-diff): `git diff <commit> <commit>` gives
"the changes between two arbitrary commits" and `git diff <commit>`
gives "the changes you have in your working tree relative to the named
commit."

This will be a breaking change, but it is an overall improvement:

command                   | current comparison | new expansion
------------------------- | ------------------ | ------------------------
`codeowners-diff foo bar` | `bar` from `foo`   | `bar` from `foo`
`codeowners-diff foo`     | `HEAD` from `foo`  | working tree from `foo`
`codeowners-diff`         | `HEAD` from `main` | working tree from `HEAD`

This opens the door to implementing some of the other options to `git
diff` in the future, if they are things we want to do with this tool.