### PR TITLE
Handle missing `CODEOWNERS` files

### DIFF
--- a/codeowners_diff.py
+++ b/codeowners_diff.py
@@ -29,11 +29,17 @@ class GitRepo:
         ).strip()
 
     def load_codeowners_file(self, ref: str) -> str:
-        return subprocess.check_output(
-            ('git', 'cat-file', 'blob', f'{ref}:.github/CODEOWNERS'),
-            cwd=self.root_dir,
-            text=True,
-        )
+        try:
+            return subprocess.check_output(
+                ('git', 'cat-file', 'blob', f'{ref}:.github/CODEOWNERS'),
+                cwd=self.root_dir,
+                text=True,
+            )
+        except subprocess.CalledProcessError as e:
+            if e.returncode == 128:
+                # the file does not exist
+                return ''
+            raise
 
     def ls_files(self, paths: Sequence[str]) -> frozenset[str]:
         if not paths:

--- a/tests/codeowners_diff_test.py
+++ b/tests/codeowners_diff_test.py
@@ -92,6 +92,21 @@ def test_find_affected_files(
     assert affected_files == expected_files
 
 
+class TestGitRepo:
+    def test_handle_missing_codeowners_file(
+            self, tmp_path_factory: pytest.TempPathFactory,
+    ) -> None:
+        # create a git repo
+        repo_root = tmp_path_factory.mktemp('repo_with_files')
+        subprocess.run(('git', 'init'), cwd=repo_root)
+
+        git_repo = codeowners_diff.GitRepo(str(repo_root))
+
+        codeowners_file = git_repo.load_codeowners_file('HEAD')
+
+        assert codeowners_file == ''
+
+
 class TestMarkdownPrinter:
     def test_render_lines(self) -> None:
         printer = codeowners_diff.MarkdownPrinter({


### PR DESCRIPTION
This will allow the tool to avoid errors if one of the commits being
checked does not have a `CODEOWNERS` file.

Fixes #53
